### PR TITLE
fixing image upload

### DIFF
--- a/custom_components/matrix/__init__.py
+++ b/custom_components/matrix/__init__.py
@@ -355,7 +355,7 @@ class MatrixBot:
 
         _LOGGER.debug("Uploading file from path, %s", image_path)
         async with aiofiles.open(image_path, "r+b") as image_file:
-            response = await self._client.upload(
+            response, _ = await self._client.upload(
                 image_file,
                 content_type=mime_type,
                 filename=os.path.basename(image_path),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,7 @@ class _MockAsyncClient(AsyncClient):
         return None
 
     async def upload(self, *args, **kwargs):
-        return UploadResponse(content_uri="mxc://example.com/randomgibberish")
+        return UploadResponse(content_uri="mxc://example.com/randomgibberish"), None
 
 
 MOCK_CONFIG_DATA = {


### PR DESCRIPTION
Image Upload is currenty broken because nio client.upload() returns a tuple instead of only the reponse. Docs: https://matrix-nio.readthedocs.io/en/latest/nio.html#nio.AsyncClient.upload

This PR fixes this.